### PR TITLE
change: some more tweaks maybe

### DIFF
--- a/.changeset/tough-snakes-eat.md
+++ b/.changeset/tough-snakes-eat.md
@@ -1,0 +1,5 @@
+---
+"hunch": patch
+---
+
+still trying to get changeset auto publishing to npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,34 +6,6 @@
 
 - ade9fa2: adding changeset to make release cycle easier
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
-Change categories are:
-
-- `Added` for new features.
-- `Changed` for changes in existing functionality.
-- `Deprecated` for once-stable features removed in upcoming releases.
-- `Removed` for deprecated features removed in this release.
-- `Fixed` for any bug fixes.
-- `Security` to invite users to upgrade in case of vulnerabilities.
-
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Fixed
-
-### Removed
-
-### Security
-
 ## [0.0.0-alpha.1](https://github.com/tobiaslabs/hunch/tree/v0.0.0-alpha.1) - 2022-12-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "email": "tobias@davistobias.com",
     "url": "https://davistobias.com"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "SEE LICENSE IN LICENSE.md",
   "bugs": {
     "url": "https://github.com/tobiaslabs/hunch/issues"


### PR DESCRIPTION
From this SO post, it suggests adding the section in the `packages.json` file: https://stackoverflow.com/questions/53420758/npm-publish-gives-unscoped-packages-cannot-be-private