### PR TITLE
Feature: snippets, aka partial results

### DIFF
--- a/.changeset/purple-cooks-explode.md
+++ b/.changeset/purple-cooks-explode.md
@@ -1,0 +1,5 @@
+---
+"hunch": minor
+---
+
+Add functionality to support "snippet" searching, e.g. return partial documents.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Hunch supports these search features:
 
 - Full text lookup [docs](https://hunchjs.com/docs/searching#full-text-lookup)
 - Fuzzy search [docs](https://hunchjs.com/docs/searching#fuzzy-search)
+- Return only partial snippet [docs](https://hunchjs.com/docs/searching#snippet)
 - Search specific fields [docs](https://hunchjs.com/docs/searching#specific-fields)
 - Prefix search [docs](https://hunchjs.com/docs/searching#prefix)
 - Search suggestions [docs](https://hunchjs.com/docs/searching#suggest)

--- a/src/hunch.js
+++ b/src/hunch.js
@@ -48,6 +48,77 @@ const filterDocuments = (searchResults, query) => {
 	})
 }
 
+const approximateTextExtraction = (string, cursor, size) => {
+	let out = ''
+	let forwardCursor = cursor + 1
+	let backwardCursor = cursor
+	let breakForward
+	let breakBackward
+	while (out.length < size) {
+		if (string[forwardCursor]) {
+			out += string[forwardCursor]
+			forwardCursor++
+		} else {
+			breakForward = true
+		}
+		if (string[backwardCursor]) {
+			out = string[backwardCursor] + out
+			backwardCursor--
+		} else {
+			breakBackward = true
+		}
+		if (breakForward && breakBackward) break
+	}
+	return out
+}
+
+const naiveSnip = (string, snippetLength, queryString, fuzzy) => {
+	// If no query string is given, we can just snip the very start of the text.
+	if (!queryString) return approximateTextExtraction(string, 0, snippetLength)
+
+	// If a blind lookup finds it, that's the cheapest way, and we'll just
+	// grab the very first result.
+	const stringLower = string.toLowerCase()
+	const queryStringLower = queryString.toLowerCase()
+	let cursor = stringLower.split(queryStringLower)
+	if (cursor.length > 1) cursor = cursor[0].length
+	if (cursor >= 0) return approximateTextExtraction(string, cursor + Math.round(queryString.length / 2), snippetLength)
+
+	// If that doesn't find it, we are dealing with a query that
+	// maybe has spaces or is fuzzy or anything else, so we're going
+	// to try throwing it at MiniSearch in chunks.
+	const paragraphs = string.split('\n')
+	const options = fuzzy >= 0
+		? { fuzzy }
+		: {}
+	const miniSearch = new MiniSearch({ fields: [ 'p' ], ...options })
+	miniSearch.addAll(paragraphs.map((p, id) => ({ p, id })))
+	const match = miniSearch.search(queryString, options)?.[0]
+	if (match) {
+		// At this point we'll try again to find the first query
+		// word in the best-matching, but using the indexed term
+		// in case fuzzing causes a mismatch.
+		const firstQueryWordLower = match.terms[0]
+		const matchingParagraph = paragraphs[match.id]
+		cursor = matchingParagraph.toLowerCase().split(firstQueryWordLower)
+		if (cursor.length > 1) cursor = cursor[0].length
+		return approximateTextExtraction(matchingParagraph, cursor + Math.round(firstQueryWordLower.length / 2), snippetLength)
+	}
+
+	// We couldn't find the query string. This is very peculiar, and I don't
+	// think it should happen, but as an emergency fallback we'll return the
+	// first text snippet.
+	return approximateTextExtraction(string, 0, snippetLength)
+}
+
+const snipContent = ({ q, snippet: propertiesToSnip, fuzzy }, searchResult) => {
+	if (propertiesToSnip)
+		for (const key in propertiesToSnip)
+			if (key === 'content') searchResult._chunk.content = naiveSnip(searchResult._chunk.content, propertiesToSnip[key], q, fuzzy)
+			else if (typeof searchResult[key] === 'string') searchResult[key] = naiveSnip(searchResult[key], propertiesToSnip[key], q, fuzzy)
+	return searchResult
+}
+
 export const hunch = ({ index: bundledIndex, sort: prePaginationSort, maxPageSize }) => {
 	const {
 		chunkIdToFileIndex,
@@ -143,7 +214,7 @@ export const hunch = ({ index: bundledIndex, sort: prePaginationSort, maxPageSiz
 			.map(({ terms: ignore1, match: ignore2, id, score, content, ...props }) => {
 				const metadata = getFileMetadata(chunkIdToFileIndex[id])
 				if (score) metadata._score = Math.round(score * 1000) / 1000
-				return {
+				return snipContent(query, {
 					...props,
 					...metadata,
 					_id: filesList[chunkIdToFileIndex[id]],
@@ -151,7 +222,7 @@ export const hunch = ({ index: bundledIndex, sort: prePaginationSort, maxPageSiz
 						...(getChunkMetadata(id) || {}),
 						content,
 					},
-				}
+				})
 			})
 
 		if (query.facetInclude || query.facetExclude) searchResults = filterDocuments(searchResults, query)

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -72,6 +72,9 @@ export const normalize = params => {
 			parsed.boost = parsed.boost || {}
 			parsed.boost[child] = parseFloat(params[key])
 			if (Number.isNaN(parsed.boost[child]) || parsed.boost[child] < 1) throw new Error(`The parameter "${key}" must be a valid float greater than 1.`)
+		} else if (parent === 'snippet') {
+			parsed.snippet = parsed.snippet || {}
+			parsed.snippet[child] = castToPositiveInt(params, key)
 		} else if (parent === 'facets') {
 			const values = castToUniqueStrings(params[key])
 			for (const val of values) {

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -18,6 +18,7 @@ const features = [
 	'pagination',
 	'prefix',
 	'score',
+	'snippet',
 	'sort',
 	'specific-fields',
 	'stop-words',

--- a/test/feature/full-text-lookup/basic.test.js
+++ b/test/feature/full-text-lookup/basic.test.js
@@ -25,59 +25,59 @@ export default (assert, search) => [
 			'only two files have "present"',
 		)
 	},
-	// () => {
-	// 	assert.equal(
-	// 		search({ q: 'words only present in' }),
-	// 		{
-	// 			items: [
-	// 				{
-	// 					_id: 'file1.md',
-	// 					_score: 12.281,
-	// 					title: 'file1',
-	// 					_chunk: { name: 'markdown', content: '\nwords only present in file1\n' },
-	// 				},
-	// 				{
-	// 					_id: 'file2.md',
-	// 					_score: 10.579,
-	// 					title: 'file2',
-	// 					_chunk: {
-	// 						name: 'markdown',
-	// 						content: '\nwords only present in file2 next part shared with file3\n',
-	// 					},
-	// 				},
-	// 			],
-	// 			page: { offset: 0, size: 15, pages: 1, items: 2 },
-	// 		},
-	// 		'only two files have the full phrase',
-	// 	)
-	// },
-	// () => {
-	// 	assert.equal(
-	// 		search({ q: 'next part shared with' }),
-	// 		{
-	// 			items: [
-	// 				{
-	// 					_id: 'file3.md',
-	// 					_score: 11.171,
-	// 					title: 'file3',
-	// 					_chunk: {
-	// 						name: 'markdown',
-	// 						content: '\nthis is file3 next part shared with file2\n',
-	// 					},
-	// 				},
-	// 				{
-	// 					_id: 'file2.md',
-	// 					_score: 10.579,
-	// 					title: 'file2',
-	// 					_chunk: {
-	// 						name: 'markdown',
-	// 						content: '\nwords only present in file2 next part shared with file3\n',
-	// 					},
-	// 				},
-	// 			],
-	// 			page: { offset: 0, size: 15, pages: 1, items: 2 },
-	// 		},
-	// 		'only two files have the full phrase',
-	// 	)
-	// },
+	() => {
+		assert.equal(
+			search({ q: 'words only present in' }),
+			{
+				items: [
+					{
+						_id: 'file1.md',
+						_score: 12.281,
+						title: 'file1',
+						_chunk: { name: 'markdown', content: '\nwords only present in file1\n' },
+					},
+					{
+						_id: 'file2.md',
+						_score: 10.579,
+						title: 'file2',
+						_chunk: {
+							name: 'markdown',
+							content: '\nwords only present in file2 next part shared with file3\n',
+						},
+					},
+				],
+				page: { offset: 0, size: 15, pages: 1, items: 2 },
+			},
+			'only two files have the full phrase',
+		)
+	},
+	() => {
+		assert.equal(
+			search({ q: 'next part shared with' }),
+			{
+				items: [
+					{
+						_id: 'file3.md',
+						_score: 11.171,
+						title: 'file3',
+						_chunk: {
+							name: 'markdown',
+							content: '\nthis is file3 next part shared with file2\n',
+						},
+					},
+					{
+						_id: 'file2.md',
+						_score: 10.579,
+						title: 'file2',
+						_chunk: {
+							name: 'markdown',
+							content: '\nwords only present in file2 next part shared with file3\n',
+						},
+					},
+				],
+				page: { offset: 0, size: 15, pages: 1, items: 2 },
+			},
+			'only two files have the full phrase',
+		)
+	},
 ]

--- a/test/feature/snippet/basic.config.js
+++ b/test/feature/snippet/basic.config.js
@@ -1,0 +1,1 @@
+export default {}

--- a/test/feature/snippet/basic.test.js
+++ b/test/feature/snippet/basic.test.js
@@ -1,0 +1,71 @@
+export default (assert, search) => [
+	() => {
+		assert.equal(
+			search({
+				q: 'which is crooked',
+				snippet: { content: 30 },
+			}),
+			{
+				items: [
+					{
+						_id: 'file1.md',
+						_score: 5.752,
+						title: 'Ecclesiastes',
+						_chunk: { name: 'markdown', content: '\nThat which is crooked can’t b' },
+					},
+				],
+				page: { offset: 0, size: 15, pages: 1, items: 1 },
+			},
+			'setting a snippet size to limit returned data',
+		)
+	},
+	() => {
+		assert.equal(
+			search({
+				q: 'heart',
+				snippet: { content: 15 },
+			}).items[0]._chunk.content,
+			' my heart to see',
+			'it has 13 results in the document but finds the "best" match in the document',
+		)
+	},
+	() => {
+		assert.equal(
+			search({
+				q: 'obtained',
+				snippet: { content: 15 },
+			}).items[0]._chunk.content,
+			've obtained for ',
+			'it only has 1 result in the document',
+		)
+	},
+	() => {
+		assert.equal(
+			search({
+				q: 'test with',
+				snippet: { content: 25 },
+			}).items[0]._chunk.content,
+			'w, I will test you with mi',
+			'a split word does a search',
+		)
+	},
+	() => {
+		assert.equal(
+			search({
+				q: 'flush',
+				snippet: { content: 100 },
+			}).items.length,
+			0,
+			'the word "flush" does not exist',
+		)
+		assert.equal(
+			search({
+				q: 'flush',
+				snippet: { content: 30 },
+				fuzzy: 0.2,
+			}).items[0]._chunk.content,
+			'o cheer my flesh with wine, my',
+			'but with fuzziness it is found',
+		)
+	},
+]

--- a/test/feature/snippet/content-basic/file1.md
+++ b/test/feature/snippet/content-basic/file1.md
@@ -1,0 +1,93 @@
+---
+title: Ecclesiastes
+---
+
+The words of the Preacher, the son of David, king in Jerusalem:
+
+“Vanity of vanities,” says the Preacher; “Vanity of vanities, all is vanity.”
+What does man gain from all his labor in which he labors under the sun?
+One generation goes, and another generation comes; but the earth remains forever.
+The sun also rises, and the sun goes down, and hurries to its place where it rises.
+The wind goes toward the south, and turns around to the north. It turns around continually as it goes, and the wind returns again to its courses.
+All the rivers run into the sea, yet the sea is not full. To the place where the rivers flow, there they flow again.
+All things are full of weariness beyond uttering. The eye is not satisfied with seeing, nor the ear filled with hearing.
+That which has been is that which shall be; and that which has been done is that which shall be done: and there is no new thing under the sun.
+Is there a thing of which it may be said, “Behold, this is new?” It has been long ago, in the ages which were before us.
+
+There is no memory of the former; neither shall there be any memory of the latter that are to come, among those that shall come after.
+
+I, the Preacher, was king over Israel in Jerusalem.
+I applied my heart to seek and to search out by wisdom concerning all that is done under the sky. It is a heavy burden that God has given to the sons of men to be afflicted with.
+I have seen all the works that are done under the sun; and behold, all is vanity and a chasing after wind.
+That which is crooked can’t be made straight; and that which is lacking can’t be counted.
+I said to myself, “Behold, I have obtained for myself great wisdom above all who were before me in Jerusalem. Yes, my heart has had great experience of wisdom and knowledge.”
+I applied my heart to know wisdom, and to know madness and folly. I perceived that this also was a chasing after wind.
+
+For in much wisdom is much grief; and he who increases knowledge increases sorrow.
+
+I said in my heart, “Come now, I will test you with mirth: therefore enjoy pleasure;” and behold, this also was vanity.
+
+I said of laughter, “It is foolishness;” and of mirth, “What does it accomplish?”
+
+I searched in my heart how to cheer my flesh with wine, my heart yet guiding me with wisdom, and how to lay hold of folly, until I might see what it was good for the sons of men that they should do under heaven all the days of their lives.
+I made myself great works. I built myself houses. I planted myself vineyards.
+I made myself gardens and parks, and I planted trees in them of all kinds of fruit.
+I made myself pools of water, to water from it the forest where trees were grown.
+I bought male servants and female servants, and had servants born in my house. I also had great possessions of herds and flocks, above all who were before me in Jerusalem.
+I also gathered silver and gold for myself, and the treasure of kings and of the provinces. I got myself male and female singers, and the delights of the sons of men: musical instruments, and that of all sorts.
+So I was great, and increased more than all who were before me in Jerusalem. My wisdom also remained with me.
+Whatever my eyes desired, I didn’t keep from them. I didn’t withhold my heart from any joy, for my heart rejoiced because of all my labor, and this was my portion from all my labor.
+
+Then I looked at all the works that my hands had worked, and at the labor that I had labored to do; and behold, all was vanity and a chasing after wind, and there was no profit under the sun.
+
+I turned myself to consider wisdom, madness, and folly; for what can the king’s successor do? Just that which has been done long ago.
+Then I saw that wisdom excels folly, as far as light excels darkness.
+The wise man’s eyes are in his head, and the fool walks in darkness—and yet I perceived that one event happens to them all.
+Then I said in my heart, “As it happens to the fool, so will it happen even to me; and why was I then more wise?” Then I said in my heart that this also is vanity.
+
+For of the wise man, even as of the fool, there is no memory forever, since in the days to come all will have been long forgotten. Indeed, the wise man must die just like the fool!
+
+So I hated life, because the work that is worked under the sun was grievous to me; for all is vanity and a chasing after wind.
+I hated all my labor in which I labored under the sun, because I must leave it to the man who comes after me.
+
+Who knows whether he will be a wise man or a fool? Yet he will have rule over all of my labor in which I have labored, and in which I have shown myself wise under the sun. This also is vanity.
+
+Therefore I began to cause my heart to despair concerning all the labor in which I had labored under the sun.
+For there is a man whose labor is with wisdom, with knowledge, and with skillfulness; yet he shall leave it for his portion to a man who has not labored for it. This also is vanity and a great evil.
+For what does a man have of all his labor and of the striving of his heart, in which he labors under the sun?
+For all his days are sorrows, and his travail is grief; yes, even in the night his heart takes no rest. This also is vanity.
+There is nothing better for a man than that he should eat and drink, and make his soul enjoy good in his labor. This also I saw, that it is from the hand of God.
+For who can eat, or who can have enjoyment, more than I?
+
+For to the man who pleases him, God gives wisdom, knowledge, and joy; but to the sinner he gives travail, to gather and to heap up, that he may give to him who pleases God. This also is vanity and a chasing after wind.
+
+For everything there is a season, and a time for every purpose under heaven:
+
+a time to be born,
+and a time to die;
+a time to plant,
+and a time to pluck up that which is planted;
+a time to kill,
+and a time to heal;
+a time to break down,
+and a time to build up;
+a time to weep,
+and a time to laugh;
+a time to mourn,
+and a time to dance;
+a time to cast away stones,
+and a time to gather stones together;
+a time to embrace,
+and a time to refrain from embracing;
+a time to seek,
+and a time to lose;
+a time to keep,
+and a time to cast away;
+a time to tear,
+and a time to sew;
+a time to keep silence,
+and a time to speak;
+a time to love,
+and a time to hate;
+a time for war,
+and a time for peace.

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -33,6 +33,10 @@ test('normalize query parameters', () => {
 		/The parameter "page\[offset]" must be a positive integer./,
 	)
 	assert.throws(
+		() => normalize({ 'snippet[content]': '-3' }),
+		/The parameter "snippet\[content]" must be a positive integer./,
+	)
+	assert.throws(
 		() => normalize({ 'prefix': 'yes' }),
 		/The parameter "prefix" must only be "true" or "false"./,
 	)
@@ -66,7 +70,7 @@ test('normalize query parameters', () => {
 			{ q: 'exact words' },
 		],
 		[
-			'',
+			'fuzzy search',
 			{ fuzzy: '0.8' },
 			{ fuzzy: 0.8 },
 		],
@@ -79,6 +83,11 @@ test('normalize query parameters', () => {
 			'prefix',
 			{ prefix: 'true' },
 			{ prefix: true },
+		],
+		[
+			'snippet size',
+			{ 'snippet[content]': '50' },
+			{ snippet: { content: 50 } },
 		],
 		[
 			'specific fields',


### PR DESCRIPTION
This is a very simple implementation, where the snippet size provided is the maximum characters to include on the search results.

I would like this to be quite a bit smarter, e.g. don't return partial words and other niceties, but this is an okay first pass.