### PR TITLE
Pagination issues

### DIFF
--- a/.changeset/unlucky-eggs-grow.md
+++ b/.changeset/unlucky-eggs-grow.md
@@ -1,0 +1,5 @@
+---
+"hunch": patch
+---
+
+Refactor pagination to make it testable, then add tests and optimize.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ name: test
 
 on:
   push:
-    branches: [ 'feature/*' ]
+    branches: [ '*' ]
+    branches-ignore: [ 'main' ]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "scripts": {
     "changeset": "changeset",
-    "test": "npm run test:lint && npm run test:feature && npm run test:normalize",
+    "test": "npm run test:lint && npm run test:feature && npm run test:functions",
     "test:feature": "node test/feature.test.js",
-    "test:normalize": "node test/normalize.test.js",
+    "test:functions": "uvu test test.js -i feature",
     "test:lint": "eslint *.js",
     "build": "rollup -c",
     "demo": "cd demo && rm -rf build && node demo.test.js",

--- a/src/utils/pagination.js
+++ b/src/utils/pagination.js
@@ -1,0 +1,30 @@
+const DEFAULT_PAGE_SIZE = 15
+
+export const getOutputWithPagination = ({ query, maxPageSize, searchResults }) => {
+	let size = query.pageSize === undefined || query.pageSize < 0
+		? DEFAULT_PAGE_SIZE
+		: query.pageSize
+	if (maxPageSize && size > maxPageSize) size = maxPageSize
+
+	const out = {
+		items: [],
+		page: {
+			items: searchResults.length,
+			size,
+		},
+	}
+
+	if (size > 0) {
+		out.page.offset = query.pageOffset || 0
+		out.page.pages = searchResults.length % size
+			? Math.ceil(searchResults.length / size) // e.g. 12/10=1.2=>Math.ceil=2 pages
+			: searchResults.length / size // e.g. 12%6=0=>12/6=2 pages
+	}
+
+	const start = size * out.page.offset // e.g. pageOffset = 3, start = 10*3 = 30
+	let end = start + size // e.g. 30+10 = 40
+	if (end > searchResults.length) end = searchResults.length
+	for (let i = start; i < end; i++) out.items.push(searchResults[i])
+
+	return out
+}

--- a/test/feature/get-facets/basic.test.js
+++ b/test/feature/get-facets/basic.test.js
@@ -6,7 +6,7 @@ export default (assert, search) => [
 			}),
 			{
 				items: [],
-				page: { items: 4 },
+				page: { items: 4, size: 0 },
 				facets: {
 					tags: {
 						dogs: 2,

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -1,0 +1,117 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+
+import { getOutputWithPagination } from '../src/utils/pagination.js'
+
+const ITEMS = size => Array(size).fill('').map((_, i) => i.toString())
+
+test('get pagination', () => {
+	assert.equal(
+		getOutputWithPagination({
+			query: {},
+			searchResults: ITEMS(100),
+		}),
+		{
+			items: ITEMS(15),
+			page: {
+				items: 100,
+				offset: 0,
+				pages: Math.ceil(100 / 15),
+				size: 15,
+			},
+		},
+		'when no page size is given and no max size is given it uses the default max',
+	)
+	assert.equal(
+		getOutputWithPagination({
+			query: {
+				pageSize: 100_000,
+			},
+			searchResults: ITEMS(100_000),
+		}),
+		{
+			items: ITEMS(100_000),
+			page: {
+				items: 100_000,
+				offset: 0,
+				pages: 1,
+				size: 100_000,
+			},
+		},
+		'when a page size is given and no max page size is set even if very big!!!',
+	)
+	assert.equal(
+		getOutputWithPagination({
+			query: {
+				pageSize: 100,
+			},
+			searchResults: ITEMS(2),
+		}),
+		{
+			items: ITEMS(2),
+			page: {
+				items: 2,
+				offset: 0,
+				pages: 1,
+				size: 100,
+			},
+		},
+		'when you set a page size bigger than result set',
+	)
+	assert.equal(
+		getOutputWithPagination({
+			query: {
+				pageSize: 100_000,
+			},
+			maxPageSize: 10,
+			searchResults: ITEMS(100_000),
+		}),
+		{
+			items: ITEMS(10),
+			page: {
+				items: 100_000,
+				offset: 0,
+				pages: 100_000 / 10,
+				size: 10,
+			},
+		},
+		'but if a max page size is set it overrides whatever is passed in',
+	)
+	assert.equal(
+		getOutputWithPagination({
+			query: {
+				pageSize: 2,
+				pageOffset: 2,
+			},
+			searchResults: ITEMS(100),
+		}),
+		{
+			items: [ '4', '5' ],
+			page: {
+				items: 100,
+				offset: 2,
+				pages: 100 / 2,
+				size: 2,
+			},
+		},
+		'if an offset is passed in it gives the correct items',
+	)
+	assert.equal(
+		getOutputWithPagination({
+			query: {
+				pageSize: 0,
+			},
+			searchResults: ITEMS(100),
+		}),
+		{
+			items: [],
+			page: {
+				items: 100,
+				size: 0,
+			},
+		},
+		'if you pass in 0 page size it just gives you an empty list',
+	)
+})
+
+test.run()


### PR DESCRIPTION
While working on a client issue, I came across some weirdness in the pagination logic, specifically when making a request where the page size was `0` (used for getting the list of facets).

In this change, I simply refactored the pagination logic out into its own file, making it easier to test, and then added a handful of tests.