### PR TITLE
Rename `normalize` and add a to-query helper

### DIFF
--- a/.changeset/silly-ways-turn.md
+++ b/.changeset/silly-ways-turn.md
@@ -1,0 +1,21 @@
+---
+"hunch": minor
+---
+
+Change the query normalization name, but also add a helper function to turn a HunchJS query object into a query search string.
+
+What you'll need to do to update:
+
+### Change imports
+
+```js
+import { normalize } from 'hunch'
+// =>
+import { fromQuery } from 'hunch'
+```
+
+```js
+import { normalize } from 'hunch/normalize'
+// =>
+import { fromQuery } from 'hunch/from-query'
+```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./from-query": {
+      "import": "./dist/from-query.js",
+      "require": "./dist/from-query.cjs"
+    },
     "./generate": {
       "import": "./dist/generate.js",
       "require": "./dist/generate.cjs"
@@ -19,9 +23,9 @@
       "import": "./dist/hunch.js",
       "require": "./dist/hunch.cjs"
     },
-    "./normalize": {
-      "import": "./dist/normalize.js",
-      "require": "./dist/normalize.cjs"
+    "./to-query": {
+      "import": "./dist/to-query.js",
+      "require": "./dist/to-query.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,9 +6,10 @@ import resolve from '@rollup/plugin-node-resolve'
 const { version } = JSON.parse(await readFile('./package.json', 'utf8'))
 
 const normal = [
+	'from-query',
 	'generate',
 	'hunch',
-	'normalize',
+	'to-query',
 ]
 
 export default [

--- a/src/from-query.js
+++ b/src/from-query.js
@@ -41,10 +41,10 @@ const castToUniqueStrings = string => ([
  * Given a query parameter object (for example a `URLSearchParams` object), return a
  * normalized set of query parameters for use by the Hunch engine.
  *
- * @param {any} params - The query parameters.
+ * @param {URLSearchParams|Object} params - The query parameters.
  * @return {QueryParameters} - The normalized parameters.
  */
-export const normalize = params => {
+export const fromQuery = params => {
 	params = params || {}
 	if (params instanceof URLSearchParams) params = castToObject(params)
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export { generate } from './generate.js'
 export { hunch } from './hunch.js'
-export { normalize } from './normalize.js'
+export { fromQuery } from './from-query.js'
+export { toQuery } from './to-query.js'

--- a/src/to-query.js
+++ b/src/to-query.js
@@ -1,0 +1,45 @@
+/**
+ * Given a HunchJS query parameter object, return a URL-safe string
+ * containing those query parameters. For example:
+ *
+ *   { pageSize: 3, q: "why? because!", facetInclude: { tags: [ "cats", "dogs" ] } }
+ *   =>
+ *   "page%5Bsize%5D=3&q=why%3F%20because!&facets%5Btags%5D=cats%2Cdogs"
+ *
+ * @param {QueryParameters} query - The normalized parameters.
+ * @return {String} - The parameters cast to a HunchJS query string.
+ */
+export const toQuery = query => {
+	const out = {}
+	if (query.id) out.id = query.id.toString()
+	if (query.pageSize !== undefined) out['page[size]'] = query.pageSize.toString()
+	if (query.pageOffset !== undefined) out['page[offset]'] = query.pageOffset.toString()
+	if (query.prefix) out.prefix = 'true'
+	if (query.suggest) out.suggest = 'true'
+	if (query.fields?.length) out.fields = query.fields.join(',')
+
+	for (const shallowKey of [ 'q', 'fuzzy' ])
+		if (query[shallowKey])
+			out[shallowKey] = query[shallowKey].toString()
+
+	for (const deepKey of [ 'boost', 'snippet' ])
+		if (query[deepKey])
+			for (const propKey in query[deepKey])
+				out[`${deepKey}[${propKey}]`] = query[deepKey][propKey].toString()
+
+	const addFacet = (facetName, value, exclude) => {
+		const flatKey = `facets[${facetName}]`
+		const prefix = exclude ? '-' : ''
+		out[flatKey] = out[flatKey]
+			? `${out[flatKey]},${prefix}${value}`
+			: `${prefix}${value}`
+	}
+	for (const deepKey of [ 'facetInclude', 'facetExclude' ])
+		if (query[deepKey])
+			for (const propKey in query[deepKey])
+				addFacet(propKey, query[deepKey][propKey].toString(), deepKey === 'facetExclude')
+
+	let params = []
+	for (const key of Object.keys(out).sort()) params.push(`${encodeURIComponent(key)}=${encodeURIComponent(out[key])}`)
+	return params.join('&')
+}

--- a/test/from-query.test.js
+++ b/test/from-query.test.js
@@ -1,11 +1,11 @@
 import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 
-import { normalize } from '../src/normalize.js'
+import { fromQuery } from '../src/from-query.js'
 
-test('normalize query parameters', () => {
+test('turn query parameters into a hunch query', () => {
 	assert.equal(
-		normalize({
+		fromQuery({
 			q: 'foo',
 			'facets[tags]': 'cats,-dogs',
 		}),
@@ -16,7 +16,7 @@ test('normalize query parameters', () => {
 		},
 	)
 	assert.equal(
-		normalize(new URL(`https://site.com?q=foo&${encodeURIComponent('facets[tags]')}=${encodeURIComponent('cats,-dogs')}`).searchParams),
+		fromQuery(new URL(`https://site.com?q=foo&${encodeURIComponent('facets[tags]')}=${encodeURIComponent('cats,-dogs')}`).searchParams),
 		{
 			q: 'foo',
 			facetInclude: { tags: [ 'cats' ] },
@@ -25,23 +25,23 @@ test('normalize query parameters', () => {
 	)
 
 	assert.throws(
-		() => normalize({ 'page[size]': '-3' }),
+		() => fromQuery({ 'page[size]': '-3' }),
 		/The parameter "page\[size]" must be a positive integer./,
 	)
 	assert.throws(
-		() => normalize({ 'page[offset]': '-3' }),
+		() => fromQuery({ 'page[offset]': '-3' }),
 		/The parameter "page\[offset]" must be a positive integer./,
 	)
 	assert.throws(
-		() => normalize({ 'snippet[content]': '-3' }),
+		() => fromQuery({ 'snippet[content]': '-3' }),
 		/The parameter "snippet\[content]" must be a positive integer./,
 	)
 	assert.throws(
-		() => normalize({ 'prefix': 'yes' }),
+		() => fromQuery({ 'prefix': 'yes' }),
 		/The parameter "prefix" must only be "true" or "false"./,
 	)
 	assert.throws(
-		() => normalize({ 'suggest': 'yes' }),
+		() => fromQuery({ 'suggest': 'yes' }),
 		/The parameter "suggest" must only be "true" or "false"./,
 	)
 
@@ -101,7 +101,7 @@ test('normalize query parameters', () => {
 		],
 	]
 	for (const [ label, query, expected ] of testEveryProperty)
-		assert.equal(normalize(query), expected, label)
+		assert.equal(fromQuery(query), expected, label)
 })
 
 test.run()

--- a/test/to-query.test.js
+++ b/test/to-query.test.js
@@ -1,0 +1,84 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+
+import { toQuery } from '../src/to-query.js'
+
+const toString = obj => {
+	let params = []
+	for (const key of Object.keys(obj).sort()) params.push(`${encodeURIComponent(key)}=${encodeURIComponent(obj[key])}`)
+	return params.join('&')
+}
+
+test('turn query parameters into a hunch query', () => {
+	assert.equal(
+		toQuery({
+			q: 'foo',
+			facetInclude: { tags: [ 'cats' ] },
+			facetExclude: { tags: [ 'dogs' ] },
+		}),
+		toString({
+			q: 'foo',
+			'facets[tags]': 'cats,-dogs',
+		}),
+	)
+
+	const testEveryProperty = [
+		[
+			'boost',
+			{ boost: { title: 2, summary: 3 } },
+			{ 'boost[title]': '2', 'boost[summary]': '3' },
+		],
+		[
+			'by id',
+			{ id: 'foo' },
+			{ id: 'foo' },
+		],
+		[
+			'facets',
+			{
+				facetInclude: { tags: [ 'cats' ] },
+				facetExclude: { tags: [ 'dogs' ] },
+			},
+			{ 'facets[tags]': 'cats,-dogs' },
+		],
+		[
+			'full text lookup',
+			{ q: 'exact words' },
+			{ q: 'exact words' },
+		],
+		[
+			'fuzzy search',
+			{ fuzzy: 0.8 },
+			{ fuzzy: '0.8' },
+		],
+		[
+			'pagination',
+			{ pageSize: 4, pageOffset: 2 },
+			{ 'page[size]': '4', 'page[offset]': '2' },
+		],
+		[
+			'prefix',
+			{ prefix: true },
+			{ prefix: 'true' },
+		],
+		[
+			'snippet size',
+			{ snippet: { content: 50 } },
+			{ 'snippet[content]': '50' },
+		],
+		[
+			'specific fields',
+			{ fields: [ 'title', 'summary' ] },
+			{ 'fields': 'title,summary' },
+		],
+		[
+			'suggestion',
+			{ suggest: true },
+			{ suggest: 'true' },
+		],
+	]
+	for (const [ label, query, expected ] of testEveryProperty)
+		assert.equal(toQuery(query), toString(expected), label)
+})
+
+test.run()


### PR DESCRIPTION
This change adds a new helper function `toQuery` which generates a query search string from a HunchJS query object, for example:

```js
import { toQuery } from 'hunch/to-query'
toQuery({ pageSize: 3, q: "why? because!", facetInclude: { tags: [ "cats", "dogs" ] } })
// =>
// facets%5Btags%5D=cats%2Cdogs&page%5Bsize%5D=3&q=why%3F%20because!
```

This change also renames the query normalization function and export to make more sense. What you'll need to do to update that is change imports:

```js
import { normalize } from 'hunch'
// =>
import { fromQuery } from 'hunch'
```

```js
import { normalize } from 'hunch/normalize'
// =>
import { fromQuery } from 'hunch/from-query'
```