### PR TITLE
Feature: dev server and watch mode

### DIFF
--- a/.changeset/curvy-parrots-rule.md
+++ b/.changeset/curvy-parrots-rule.md
@@ -1,0 +1,5 @@
+---
+"hunch": minor
+---
+
+You can pass in the `--serve` flag to get a simple HTTP server, using canonical query parameters.

--- a/.changeset/perfect-hornets-care.md
+++ b/.changeset/perfect-hornets-care.md
@@ -1,0 +1,5 @@
+---
+"hunch": minor
+---
+
+You can pass in `--watch` and the index will be rebuilt on content changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "hunch",
-  "version": "0.0.5",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hunch",
-      "version": "0.0.5",
+      "version": "0.3.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
-        "hunch": "bin.cjs"
+        "hunch": "bin.js"
       },
       "devDependencies": {
         "@changesets/cli": "^2.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@rollup/plugin-replace": "^5.0.2",
         "@saibotsivad/blockdown": "^3.0.0",
         "@saibotsivad/eslint-config-saibotsivad": "*",
+        "cheap-watch": "^1.0.4",
         "js-yaml": "^4.1.0",
         "minisearch": "^6.0.0",
         "rollup": "^3.9.0",
@@ -1623,6 +1624,15 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/cheap-watch": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cheap-watch/-/cheap-watch-1.0.4.tgz",
+      "integrity": "sha512-QR/9FrtRL5fjfUJBhAKCdi0lSRQ3rVRRum3GF9wDKp2TJbEIMGhUEr2yU8lORzm9Isdjx7/k9S0DFDx+z5VGtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ci-info": {
       "version": "3.7.1",
@@ -6203,6 +6213,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cheap-watch": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cheap-watch/-/cheap-watch-1.0.4.tgz",
+      "integrity": "sha512-QR/9FrtRL5fjfUJBhAKCdi0lSRQ3rVRRum3GF9wDKp2TJbEIMGhUEr2yU8lORzm9Isdjx7/k9S0DFDx+z5VGtw==",
       "dev": true
     },
     "ci-info": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "npm run test:lint && npm run test:feature && npm run test:functions",
     "test:feature": "node test/feature.test.js",
     "test:functions": "uvu test test.js -i feature",
-    "test:lint": "eslint *.js",
+    "test:lint": "eslint 'src/**/*.js' 'bin.js' 'rollup.config.js'",
     "build": "rollup -c",
     "demo": "cd demo && rm -rf build && node demo.test.js",
     "demo-server": "node src/cli.js --cwd demo --config demo/hunch.demo-config.js --serve 3001",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:lint": "eslint 'src/**/*.js' 'bin.js' 'rollup.config.js'",
     "build": "rollup -c",
     "demo": "cd demo && rm -rf build && node demo.test.js",
-    "demo-server": "node src/cli.js --cwd demo --config demo/hunch.demo-config.js --serve 3001",
+    "demo-server": "node src/cli.js --cwd demo --config demo/hunch.demo-config.js --serve 3001 --watch",
     "release": "npm run build && changeset publish"
   },
   "repository": {
@@ -70,6 +70,7 @@
     "@rollup/plugin-replace": "^5.0.2",
     "@saibotsivad/blockdown": "^3.0.0",
     "@saibotsivad/eslint-config-saibotsivad": "*",
+    "cheap-watch": "^1.0.4",
     "js-yaml": "^4.1.0",
     "minisearch": "^6.0.0",
     "rollup": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:lint": "eslint *.js",
     "build": "rollup -c",
     "demo": "cd demo && rm -rf build && node demo.test.js",
+    "demo-server": "node src/cli.js --cwd demo --config demo/hunch.demo-config.js --serve 3001",
     "release": "npm run build && changeset publish"
   },
   "repository": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, resolve, isAbsolute } from 'node:path'
+import CheapWatch from 'cheap-watch'
 import sade from 'sade'
 
 import { generate } from './generate.js'
@@ -17,24 +18,55 @@ const humanBytes = bytes => {
 	else return `${Math.round(bytes / 100_000) / 10} MB`
 }
 
-const run = async ({ config, cwd, serve, indent, verbose }) => {
-	const { default: opts } = await import(config)
-	let { output: outputFilepath } = opts
-
-	if (!outputFilepath) throw new Error('Must specify an output filepath.')
-	if (!isAbsolute(outputFilepath)) outputFilepath = resolve(cwd, outputFilepath)
-	await mkdir(dirname(outputFilepath), { recursive: true })
-
+const build = async ({ cwd, indent, opts, outputFilepath, verbose }) => {
 	const outputData = await generate({ ...opts, cwd, verbose })
 	const string = JSON.stringify(outputData, undefined, indent ? '\t' : '')
 	console.log('Index file size:', humanBytes(new TextEncoder().encode(string).length))
 	await writeFile(outputFilepath, string, 'utf8')
-
-	if (serve) await startServer({
-		port: typeof serve === 'number' ? serve : 9001,
-		index: outputData,
-	})
+	return outputData
 }
+
+const run = async ({ config, cwd, indent, serve, verbose, watch }) => new Promise(
+	(resolvePromise, rejectPromise) => import(config)
+		.then(({ default: opts }) => {
+			const port = typeof serve === 'number' ? serve : 9001
+			let { output: outputFilepath } = opts
+			if (!outputFilepath) throw new Error('Must specify an output filepath.')
+			if (!isAbsolute(outputFilepath)) outputFilepath = resolve(cwd, outputFilepath)
+			mkdir(dirname(outputFilepath), { recursive: true })
+				.then(() => {
+					if (watch) {
+						const watch = new CheapWatch({
+							dir: isAbsolute(opts.input)
+								? opts.input
+								: resolve(cwd, opts.input),
+							debounce: 80,
+						})
+						const rebuildIndex = () => {
+							console.log('Rebuilding index, one moment...')
+							build({ cwd, indent, opts, outputFilepath, serve, verbose })
+								.then(index => { if (serve) startServer({ port, index }) })
+								.catch(error => {
+									console.error('Error while building index:', error)
+								})
+						}
+						watch.on('+', rebuildIndex)
+						watch.on('-', rebuildIndex)
+						watch.init().then(() => {
+							rebuildIndex()
+						})
+					} else {
+						build({ cwd, indent, opts, outputFilepath, serve, verbose })
+							.then(index => {
+								if (serve) startServer({ port, index })
+								else resolvePromise()
+							})
+					}
+				})
+				.catch(rejectPromise)
+		})
+		.catch(rejectPromise),
+)
 
 const cli = sade('hunch', true)
 
@@ -43,20 +75,21 @@ cli
 	.describe('Compiled search for your static Markdown files.')
 	.option('-c, --config', 'Path to configuration file.', 'hunch.config.js')
 	.option('--cwd', 'Set the current working directory somewhere else.')
-	.option('--serve', 'Start a search server using canonical query parameters. (Default port: 9001)')
 	.option('--indent', 'Indent the output JSON, typically for debugging purposes.')
+	.option('--serve', 'Start a search server using canonical query parameters. (Default port: 9001)')
 	.option('--verbose', 'Print additional information during build.')
+	.option('-w, --watch', 'Rebuild the index on input file changes.')
 	.example('--config hunch.config.js')
 	.example('-c hunch.config.js')
 	.example('--config hunch.config.js --cwd ../../ --indent --verbose')
 	.example('--serve 8080 # change the port')
-	.action(({ config, cwd, serve, indent, verbose }) => {
+	.action(({ config, cwd, indent, serve, verbose, watch }) => {
 		cwd = cwd || process.cwd()
 		if (!isAbsolute(cwd)) cwd = resolve(cwd)
 		if (typeof config !== 'string') config = 'hunch.config.js'
 		if (!isAbsolute(config)) config = resolve(config)
 		const start = Date.now()
-		run({ config, cwd, serve, indent, verbose })
+		run({ config, cwd, indent, serve, verbose, watch })
 			.then(() => {
 				console.log(`Hunch completed in ${humanTime(Date.now() - start)}.`)
 				process.exit(0)

--- a/src/hunch.js
+++ b/src/hunch.js
@@ -211,6 +211,7 @@ export const hunch = ({ index: bundledIndex, sort: prePaginationSort, maxPageSiz
 		}
 		searchResults = searchResults
 			.filter(r => chunkIdToKeep[r.id])
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			.map(({ terms: ignore1, match: ignore2, id, score, content, ...props }) => {
 				const metadata = getFileMetadata(chunkIdToFileIndex[id])
 				if (score) metadata._score = Math.round(score * 1000) / 1000

--- a/src/utils/server.js
+++ b/src/utils/server.js
@@ -5,11 +5,11 @@ import { createServer } from 'node:http'
 
 const HOSTNAME = '127.0.0.1'
 let server
-export const startServer = ({ port, index }) => new Promise(() => {
+export const startServer = ({ port, index }) => {
 	if (server) server.close(() => {
 		console.log('HunchJS server restarting due to index changes...')
 		server = undefined
-		setTimeout(() => { startServer({ port }) })
+		setTimeout(() => { startServer({ port, index }) })
 	})
 	else {
 		const search = hunch({ index })
@@ -38,4 +38,4 @@ export const startServer = ({ port, index }) => new Promise(() => {
 			console.log(`HunchJS server running: http://${HOSTNAME}:${port}/`)
 		})
 	}
-})
+}

--- a/src/utils/server.js
+++ b/src/utils/server.js
@@ -1,0 +1,41 @@
+import { fromQuery } from '../from-query.js'
+import { hunch } from '../hunch.js'
+
+import { createServer } from 'node:http'
+
+const HOSTNAME = '127.0.0.1'
+let server
+export const startServer = ({ port, index }) => new Promise(() => {
+	if (server) server.close(() => {
+		console.log('HunchJS server restarting due to index changes...')
+		server = undefined
+		setTimeout(() => { startServer({ port }) })
+	})
+	else {
+		const search = hunch({ index })
+		server = createServer((req, res) => {
+			console.log(new Date(), req.method, req.url)
+			const { searchParams } = new URL(`https://${HOSTNAME}${req.url}`)
+			let body
+			let statusCode = 200
+			res.setHeader('content-type', 'application/json')
+			try {
+				const query = fromQuery(searchParams)
+				body = search(query)
+			} catch (error) {
+				statusCode = 500
+				body = {
+					error: {
+						name: error.constructor?.name || error.name,
+						message: error.message,
+					},
+				}
+			}
+			res.statusCode = statusCode
+			res.end(JSON.stringify(body, undefined, 4))
+		})
+		server.listen(port, () => {
+			console.log(`HunchJS server running: http://${HOSTNAME}:${port}/`)
+		})
+	}
+})

--- a/src/utils/unpack.js
+++ b/src/utils/unpack.js
@@ -87,6 +87,7 @@ export const unpack = ({
 	const inMemoryFileMetadataCache = {}
 	unpacked.getFileMetadata = fileId => {
 		if (!inMemoryFileMetadataCache[fileId]) {
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			const { content: ignore, ...overallFields } = miniSearch.storedFields[fileIdToDocumentIds[fileId][0]] || {}
 			inMemoryFileMetadataCache[fileId] = {
 				...unpackTree(fileId, fileMetadata),


### PR DESCRIPTION
Watch content files and rebuild the index on changes by using the `--watch` or `-w` flag.

Launch a simple HTTP server that uses the [optional-but-canonical HunchJS query parameters](https://hunchjs.com/docs/searching#query-object-to-hunch-search) by using the `--serve` flag. Pick a port with `--serve 9001`.