### PR TITLE
Some dev features and adding exact-search

### DIFF
--- a/.changeset/few-eels-grab.md
+++ b/.changeset/few-eels-grab.md
@@ -1,0 +1,5 @@
+---
+"hunch": minor
+---
+
+Prettify logged query parameters when running local dev server.

--- a/.changeset/great-brooms-chew.md
+++ b/.changeset/great-brooms-chew.md
@@ -1,0 +1,5 @@
+---
+"hunch": minor
+---
+
+You can set `--delay N` when using `--serve` to simulate slow network responses.

--- a/.changeset/mean-jokes-joke.md
+++ b/.changeset/mean-jokes-joke.md
@@ -1,0 +1,5 @@
+---
+"hunch": minor
+---
+
+Add ability to filter with quotation marks describing exact matches.

--- a/.changeset/shiny-camels-cheer.md
+++ b/.changeset/shiny-camels-cheer.md
@@ -1,0 +1,5 @@
+---
+"hunch": patch
+---
+
+Add tests for very large data sets to validate performance is acceptable.

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ globbed-*.js
 /dist
 /demo/build
 /test/feature/*/build
+/test/feature/huge-text-search/content-basic

--- a/.idea/hunch.iml
+++ b/.idea/hunch.iml
@@ -7,6 +7,7 @@
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/demo/build" />
       <excludeFolder url="file://$MODULE_DIR$/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/test/feature/huge-text-search/content-basic" />
       <excludePattern pattern="build" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hunch",
-  "version": "0.3.2",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hunch",
-      "version": "0.3.2",
+      "version": "0.6.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "hunch": "bin.js"
@@ -24,7 +24,8 @@
         "rollup": "^3.9.0",
         "sade": "^1.8.1",
         "tiny-glob": "^0.2.9",
-        "uvu": "^0.5.6"
+        "uvu": "^0.5.6",
+        "world-english-bible": "^1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4885,6 +4886,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/world-english-bible": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/world-english-bible/-/world-english-bible-1.0.0.tgz",
+      "integrity": "sha512-4/0uF+51k+FkOs1ZsC5LmAdhAmD24Ng76RfKIeJgVxZO6pcMk3ekKQMeaDn++y4F5xPhXPOguYFYL/5c68DMOA==",
+      "dev": true
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -8658,6 +8665,12 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true,
       "peer": true
+    },
+    "world-english-bible": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/world-english-bible/-/world-english-bible-1.0.0.tgz",
+      "integrity": "sha512-4/0uF+51k+FkOs1ZsC5LmAdhAmD24Ng76RfKIeJgVxZO6pcMk3ekKQMeaDn++y4F5xPhXPOguYFYL/5c68DMOA==",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "changeset": "changeset",
     "test": "npm run test:lint && npm run test:feature && npm run test:functions",
+    "pretest:feature": "node test/generate-huge-text.js",
     "test:feature": "node test/feature.test.js",
     "test:functions": "uvu test test.js -i feature",
     "test:lint": "eslint 'src/**/*.js' 'bin.js' 'rollup.config.js'",
@@ -76,6 +77,7 @@
     "rollup": "^3.9.0",
     "sade": "^1.8.1",
     "tiny-glob": "^0.2.9",
-    "uvu": "^0.5.6"
+    "uvu": "^0.5.6",
+    "world-english-bible": "^1.0.0"
   }
 }

--- a/src/hunch.js
+++ b/src/hunch.js
@@ -2,6 +2,7 @@ import MiniSearch from 'minisearch'
 
 import { unpack } from './utils/unpack.js'
 import { getOutputWithPagination } from './utils/pagination.js'
+import { filterForMatchingPhrases } from './utils/filter-for-matching-phrases.js'
 
 const EMPTY_RESULTS = {
 	items: [],
@@ -200,6 +201,7 @@ export const hunch = ({ index: bundledIndex, sort: prePaginationSort, maxPageSiz
 		let searchResults = []
 
 		if (!mini && (query.q || query.suggest)) init()
+
 		if (query.suggest) {
 			return {
 				suggestions: mini
@@ -215,6 +217,7 @@ export const hunch = ({ index: bundledIndex, sort: prePaginationSort, maxPageSiz
 			// the MiniSearch properties, so we can direct copy.
 			for (const key of [ 'boost', 'fields', 'fuzzy', 'prefix' ]) if (query[key]) miniOptions[key] = query[key]
 			searchResults = mini.search(query.q, miniOptions)
+			if (query.q.includes('"') || query.q.includes("'")) searchResults = filterForMatchingPhrases(query.q, searchResults)
 		} else {
 			// loading *all* documents, but only the first chunk
 			for (const documentId in miniSearch.documentIds) {

--- a/src/utils/filter-for-matching-phrases.js
+++ b/src/utils/filter-for-matching-phrases.js
@@ -1,0 +1,86 @@
+// Match on pairs of single or double quotes, e.g.:
+// - "wireless chargers"
+// - hello "there general" kenobi
+// - why 'hello there'
+// - even "multiple kinds" of 'quotes are allowed'
+const QUOTED_PHRASE = /"([^"]+)"|'([^']+)'/g
+
+const SPACES_SPLIT = /\s+/
+
+export const filterForMatchingPhrases = (queryString, searchResults) => {
+	const phrases = [
+		// from `search "wireless    chargers" now` we get
+		// {
+		//   words: [ 'wireless', 'chargers' ],
+		//   regex: 'wireless\s+chargers',
+		// }
+	]
+	for (const match of queryString.toLowerCase().matchAll(QUOTED_PHRASE)) if (match[1] || match[2]) {
+		const words = (match[1] || match[2]).split(SPACES_SPLIT)
+		phrases.push({
+			words,
+			regex: new RegExp(words.join('\\s+'), 'i'),
+		})
+	}
+	if (!phrases.length) return searchResults
+
+	/*
+	Search result items from MiniSearch look like this:
+
+		{
+			terms: [ 'wireless', 'chargers' ],
+			match: { wireless: [ 'content' ], chargers: [ 'content' ] },
+			content: 'cars with wireless phone chargers are interesting',
+		}
+
+	If there are quoted phrases in the query string, we want to make sure
+	that the returned items pass two filters:
+
+	1. If every word in the phrase is in the same matched property. E.g.
+	for "wireless chargers" if "wireless" is in the title but "chargers"
+	is only in the content, that's not a match.
+
+	2. Make sure that the entire phrase is found together in the matching
+	property, e.g. the phrase "wireless chargers" is found.
+	*/
+
+	const matchingSearchResults = []
+	for (const item of searchResults) {
+		const propertyToTerm = {}
+		for (const term in item.match)
+			for (const prop of item.match[term]) {
+				propertyToTerm[prop] = propertyToTerm[prop] || {}
+				propertyToTerm[prop][term] = 1 // truthy for filtering later
+			}
+
+		let passes
+		for (const { words, regex } of phrases) {
+			// Make sure the whole phrase is present, since MiniSearch can
+			// return results that don't contain every word.
+			if (!words.every(w => item.terms.includes(w))) {
+				passes = false
+				break
+			}
+
+			// Must have at least one property that contains every term.
+			const propertiesContainingAllWords = Object
+				.keys(propertyToTerm)
+				.filter(prop => words.every(word => propertyToTerm[prop][word]))
+			if (!propertiesContainingAllWords.length) {
+				passes = false
+				break
+			}
+
+			// And one of those properties needs to match all words being together.
+			if (propertiesContainingAllWords.find(prop => regex.test(item[prop]))) {
+				passes = true
+			} else {
+				passes = false
+				break
+			}
+		}
+		if (passes) matchingSearchResults.push(item)
+	}
+
+	return matchingSearchResults
+}

--- a/src/utils/server.js
+++ b/src/utils/server.js
@@ -1,24 +1,35 @@
+import { createServer } from 'node:http'
+import { setTimeout as timeoutDelay } from 'node:timers'
+
 import { fromQuery } from '../from-query.js'
 import { hunch } from '../hunch.js'
 
-import { createServer } from 'node:http'
+const prettify = url => {
+	let [ pre, query ] = url.split('?')
+	const parts = []
+	for (const chunk of query.split('&')) {
+		const [ key, value ] = chunk.split('=')
+		parts.push(`${decodeURIComponent(key)}=${decodeURIComponent(value)}`)
+	}
+	query = parts.sort().join('&')
+	return pre + '?' + query
+}
 
 const HOSTNAME = '127.0.0.1'
 let server
-export const startServer = ({ port, index }) => {
+export const startServer = ({ port, index, delay }) => {
 	if (server) server.close(() => {
 		console.log('HunchJS server restarting due to index changes...')
 		server = undefined
-		setTimeout(() => { startServer({ port, index }) })
+		setTimeout(() => { startServer({ port, index, delay }) })
 	})
 	else {
 		const search = hunch({ index })
 		server = createServer((req, res) => {
-			console.log(new Date(), req.method, req.url)
+			console.log(new Date(), req.method, prettify(req.url))
 			const { searchParams } = new URL(`https://${HOSTNAME}${req.url}`)
 			let body
 			let statusCode = 200
-			res.setHeader('content-type', 'application/json')
 			try {
 				const query = fromQuery(searchParams)
 				body = search(query)
@@ -31,8 +42,11 @@ export const startServer = ({ port, index }) => {
 					},
 				}
 			}
-			res.statusCode = statusCode
-			res.end(JSON.stringify(body, undefined, 4))
+			timeoutDelay(() => {
+				res.setHeader('content-type', 'application/json')
+				res.statusCode = statusCode
+				res.end(JSON.stringify(body, undefined, 4))
+			}, delay)
 		})
 		server.listen(port, () => {
 			console.log(`HunchJS server running: http://${HOSTNAME}:${port}/`)

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -26,6 +26,7 @@ const features = namedFeature
 		'full-text-lookup',
 		'fuzzy-search',
 		'get-facets',
+		'huge-text-search',
 		'pagination',
 		'prefix',
 		'quoted-search',

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -28,6 +28,7 @@ const features = namedFeature
 		'get-facets',
 		'pagination',
 		'prefix',
+		'quoted-search',
 		'return-specific-facets',
 		'return-specific-fields',
 		'score',

--- a/test/feature/huge-text-search/basic.config.js
+++ b/test/feature/huge-text-search/basic.config.js
@@ -1,0 +1,1 @@
+export default {}

--- a/test/feature/huge-text-search/basic.test.js
+++ b/test/feature/huge-text-search/basic.test.js
@@ -1,0 +1,50 @@
+export default ({ assert, hunch, index }) => [
+	() => {
+		assert.equal(
+			hunch({ index })({
+				q: 'present',
+				pageSize: 1,
+				snippet: {
+					content: 100,
+				},
+			}),
+			{
+				items: [
+					{
+						_id: 'romans/chapter-6.md',
+						_score: 6.103,
+						_chunk: { name: 'markdown', content: 'u should obey it in its lusts.  Also, do not present your members to sin as instruments of unrighteo' },
+					},
+				],
+				page: { offset: 0, size: 1, pages: 69, items: 69 },
+			},
+			'make sure basic text lookup works',
+		)
+	},
+	() => {
+		const start = Date.now()
+		const results = hunch({ index })({
+			q: 'do not present your members',
+			pageSize: 1,
+			snippet: {
+				content: 100,
+			},
+		})
+		const duration = Date.now() - start
+		assert.equal(
+			results,
+			{
+				items: [
+					{
+						_id: 'romans/chapter-6.md',
+						_score: 98.146,
+						_chunk: { name: 'markdown', content: 'hould obey it in its lusts.  Also, do not present your members to sin as instruments of unrighteousn' },
+					},
+				],
+				page: { offset: 0, size: 1, pages: 775, items: 775 },
+			},
+			'looking for long phrases',
+		)
+		assert.ok(duration < 1000, `approximate hard limit on time (duration=${duration})`)
+	},
+]

--- a/test/feature/quoted-search/basic.config.js
+++ b/test/feature/quoted-search/basic.config.js
@@ -1,0 +1,1 @@
+export default {}

--- a/test/feature/quoted-search/basic.test.js
+++ b/test/feature/quoted-search/basic.test.js
@@ -1,0 +1,65 @@
+export default ({ assert, hunch, index }) => [
+	() => {
+		assert.equal(
+			hunch({ index })({
+				q: 'wireless chargers',
+			}),
+			{
+				items: [
+					{
+						_id: 'file1.md',
+						_score: 1.113,
+						title: 'file1',
+						_chunk: { name: 'markdown', content: '\ncars with wireless chargers are interesting\n' },
+					},
+					{
+						_id: 'file2.md',
+						_score: 1.076,
+						title: 'file2',
+						_chunk: { name: 'markdown', content: '\ncars with wireless phone chargers are interesting\n' },
+					},
+				],
+				page: { offset: 0, size: 15, pages: 1, items: 2 },
+			},
+			'results without quotes includes both',
+		)
+	},
+	() => {
+		assert.equal(
+			hunch({ index })({
+				q: '"wireless chargers"',
+			}),
+			{
+				items: [
+					{
+						_id: 'file1.md',
+						_score: 1.113,
+						title: 'file1',
+						_chunk: { name: 'markdown', content: '\ncars with wireless chargers are interesting\n' },
+					},
+				],
+				page: { offset: 0, size: 15, pages: 1, items: 1 },
+			},
+			'results with quotes includes only the one',
+		)
+	},
+	() => {
+		assert.equal(
+			hunch({ index })({
+				q: 'cars \'wireless chargers\' "are interesting"',
+			}),
+			{
+				items: [
+					{
+						_id: 'file1.md',
+						_score: 6.956,
+						title: 'file1',
+						_chunk: { name: 'markdown', content: '\ncars with wireless chargers are interesting\n' },
+					},
+				],
+				page: { offset: 0, size: 15, pages: 1, items: 1 },
+			},
+			'results with quotes includes only the one',
+		)
+	},
+]

--- a/test/feature/quoted-search/content-basic/file1.md
+++ b/test/feature/quoted-search/content-basic/file1.md
@@ -1,0 +1,5 @@
+---
+title: file1
+---
+
+cars with wireless chargers are interesting

--- a/test/feature/quoted-search/content-basic/file2.md
+++ b/test/feature/quoted-search/content-basic/file2.md
@@ -1,0 +1,5 @@
+---
+title: file2
+---
+
+cars with wireless phone chargers are interesting

--- a/test/filter-for-matching-phrases.test.js
+++ b/test/filter-for-matching-phrases.test.js
@@ -1,0 +1,84 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+
+import { filterForMatchingPhrases } from '../src/utils/filter-for-matching-phrases.js'
+
+const getIds = item => item.id
+
+test('turn query parameters into a hunch query', () => {
+	assert.equal(
+		filterForMatchingPhrases(
+			'"wireless chargers"',
+			[
+				{
+					id: '0:0',
+					terms: [ 'wireless', 'chargers' ],
+					match: { wireless: [ 'content' ], chargers: [ 'content' ] },
+					content: '\ncars with wireless phone chargers are interesting\n',
+				},
+				{
+					id: '1:0',
+					terms: [ 'wireless', 'chargers' ],
+					match: { wireless: [ 'content' ], chargers: [ 'content' ] },
+					content: '\ncars with wireless chargers are interesting\n',
+				},
+			],
+		).map(getIds),
+		[
+			'1:0',
+		],
+		'matches the one that has the search phrase as exact',
+	)
+	assert.equal(
+		filterForMatchingPhrases(
+			'"wIrElEsS chargers"',
+			[
+				{
+					id: '1:0',
+					terms: [ 'wireless', 'chargers' ],
+					match: { wireless: [ 'content' ], chargers: [ 'content' ] },
+					content: '\ncars with WiReLeSs chargers are interesting\n',
+				},
+			],
+		).map(getIds),
+		[
+			'1:0',
+		],
+		'case is ignored both on the search query and the item properties',
+	)
+	assert.equal(
+		filterForMatchingPhrases(
+			'"wireless chargers"',
+			[
+				{
+					id: '0:0',
+					terms: [ 'wireless', 'chargers' ],
+					match: { wireless: [ 'content' ], chargers: [ 'title' ] },
+					content: '\nwireless cars\n',
+					title: 'chargers today',
+				},
+			],
+		).map(getIds),
+		[],
+		'since the phrase was not on the same property it does not match',
+	)
+	assert.equal(
+		filterForMatchingPhrases(
+			'cars with "wireless chargers"',
+			[
+				{
+					id: '1:0',
+					terms: [ 'cars', 'with', 'wireless', 'chargers' ],
+					match: { cars: [ 'content' ], with: [ 'content' ], wireless: [ 'content' ], chargers: [ 'content' ] },
+					content: '\ncars with wireless chargers are interesting\n',
+				},
+			],
+		).map(getIds),
+		[
+			'1:0',
+		],
+		'the quoted phrase is in the terms but the terms contains more than only the quoted phrase',
+	)
+})
+
+test.run()

--- a/test/generate-huge-text.js
+++ b/test/generate-huge-text.js
@@ -1,0 +1,42 @@
+import { readFile, writeFile, readdir, rm, mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const contentDir = join(__dirname, 'feature', 'huge-text-search', 'content-basic')
+await rm(contentDir, { recursive: true, force: true })
+await mkdir(contentDir)
+
+const jsonDir = join(__dirname, '..', 'node_modules', 'world-english-bible', 'json')
+const bibleBookFileNames = await readdir(jsonDir)
+
+const chapterFrontmatter = (book, chapter) => `---
+book: ${book}
+chapter: ${chapter}
+---
+
+`
+
+for (const bookFileName of bibleBookFileNames) {
+	const bookDir = join(contentDir, bookFileName.replace(/\.json$/, ''))
+	await mkdir(bookDir)
+	const book = JSON.parse(await readFile(join(jsonDir, bookFileName), 'utf8'))
+	let currentChapterNumber
+	let chapterCollector
+	for (const { type, chapterNumber, value } of book) {
+		if (chapterNumber && chapterNumber !== currentChapterNumber) {
+			if (currentChapterNumber && chapterCollector) {
+				console.log(`Writing chapter ${currentChapterNumber} of ${bookFileName}`)
+				await writeFile(join(bookDir, `chapter-${currentChapterNumber}.md`), chapterCollector, 'utf8')
+			}
+			currentChapterNumber = chapterNumber
+			chapterCollector = chapterFrontmatter(bookFileName, chapterNumber)
+		}
+		if (type === 'paragraph start' || type === 'paragraph text') {
+			chapterCollector += (value || '')
+		} else if (type === 'paragraph end') {
+			chapterCollector += '\n\n'
+		}
+	}
+}


### PR DESCRIPTION
Added a few things:

- When you are using `--serve` for local development, you can also add `--delay N` (where `N` is a positive integer) to add a number of milliseconds delay on search responses. This can be used to simulate network traffic, to make sure your application UX is handling potentially-slow HTTP requests.
- You can use quote marks (single or double) to describe exact matches, e.g. `wireless charger` would include `wireless phone charger` but `"wireless charger"` would not.
- No serious benchmarks yet, but started to get that set up by adding a test of a very large data set.