### PR TITLE
Add tests and fix bugs for multiple-chunk documents

### DIFF
--- a/.changeset/gold-chefs-collect.md
+++ b/.changeset/gold-chefs-collect.md
@@ -1,0 +1,5 @@
+---
+"hunch": patch
+---
+
+Fixed unpacking algorithm for multiple chunks.

--- a/.changeset/thick-toys-design.md
+++ b/.changeset/thick-toys-design.md
@@ -1,0 +1,5 @@
+---
+"hunch": patch
+---
+
+Add demo test for how multiple chunks are searched.

--- a/src/utils/unpack.js
+++ b/src/utils/unpack.js
@@ -58,7 +58,11 @@ export const unpack = ({
 		searchableFields: searchableFields || [],
 		_minisearchOptions: _minisearchOptions || {},
 	}
-	for (const fileId in fileIdToDocumentIds) unpacked.chunkIdToFileIndex[miniSearch.documentIds[fileIdToDocumentIds[fileId]]] = fileId
+	for (const fileId in fileIdToDocumentIds) {
+		for (const documentId of fileIdToDocumentIds[fileId]) {
+			unpacked.chunkIdToFileIndex[miniSearch.documentIds[documentId]] = fileId
+		}
+	}
 
 	if (stopWords?.length) {
 		const words = new Set(stopWords)

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -28,6 +28,7 @@ const features = namedFeature
 		'fuzzy-search',
 		'get-facets',
 		'huge-text-search',
+		'multiple-chunks',
 		'pagination',
 		'prefix',
 		'return-specific-facets',

--- a/test/feature/multiple-chunks/basic.config.js
+++ b/test/feature/multiple-chunks/basic.config.js
@@ -1,0 +1,1 @@
+export default {}

--- a/test/feature/multiple-chunks/basic.test.js
+++ b/test/feature/multiple-chunks/basic.test.js
@@ -1,0 +1,40 @@
+export default ({ assert, hunch, index }) => [
+	() => {
+		assert.equal(
+			hunch({ index })({
+				q: 'exciting',
+			}),
+			{
+				items: [
+					{
+						_id: 'file1.md',
+						_score: 1.004,
+						title: 'file1',
+						_chunk: { name: 'markdown', content: '\nSome exciting words.\n' },
+					},
+				],
+				page: { offset: 0, size: 15, pages: 1, items: 1 },
+			},
+			'it returns the chunk that best matches',
+		)
+	},
+	() => {
+		assert.equal(
+			hunch({ index })({
+				q: 'more',
+			}),
+			{
+				items: [
+					{
+						_id: 'file1.md',
+						_score: 1.08,
+						title: 'file1',
+						_chunk: { name: 'markdown', content: '\nMore words.\n' },
+					},
+				],
+				page: { offset: 0, size: 15, pages: 1, items: 1 },
+			},
+			'so here it will return the second chunk instead',
+		)
+	},
+]

--- a/test/feature/multiple-chunks/content-basic/file1.md
+++ b/test/feature/multiple-chunks/content-basic/file1.md
@@ -1,0 +1,9 @@
+---
+title: file1
+---
+
+Some exciting words.
+
+---!markdown
+
+More words.

--- a/test/generate-huge-text.js
+++ b/test/generate-huge-text.js
@@ -27,7 +27,6 @@ for (const bookFileName of bibleBookFileNames) {
 	for (const { type, chapterNumber, value } of book) {
 		if (chapterNumber && chapterNumber !== currentChapterNumber) {
 			if (currentChapterNumber && chapterCollector) {
-				console.log(`Writing chapter ${currentChapterNumber} of ${bookFileName}`)
 				await writeFile(join(bookDir, `chapter-${currentChapterNumber}.md`), chapterCollector, 'utf8')
 			}
 			currentChapterNumber = chapterNumber


### PR DESCRIPTION
I added a test to increase coverage, and found in the process that multiple-chunk documents were not correctly implemented in the unpacking algorithm.