### PR TITLE
Some work on snippets

### DIFF
--- a/.changeset/breezy-glasses-invent.md
+++ b/.changeset/breezy-glasses-invent.md
@@ -1,0 +1,5 @@
+---
+"hunch": minor
+---
+
+Snippets are now slightly context aware and let you know if there are words before or after the result string.

--- a/src/utils/snip-content.js
+++ b/src/utils/snip-content.js
@@ -1,0 +1,137 @@
+import MiniSearch from 'minisearch'
+
+const LOOK_AROUND = 3
+const WORD_BOUNDARY_CHARS = new Set([
+	' ',
+	'\n',
+])
+
+const approximateTextExtraction = (string, cursor, size, wordBoundaryCharacters = WORD_BOUNDARY_CHARS) => {
+	if (size === 0) return { string: '' }
+
+	let out = ''
+	let forwardCursor = cursor
+	let backwardCursor = cursor - 1
+	let breakForward
+	let breakBackward
+	while (out.length < (size + LOOK_AROUND)) {
+		if (!breakForward && string[forwardCursor]) {
+			out += string[forwardCursor]
+			forwardCursor++
+		} else {
+			breakForward = true
+		}
+		if (!breakBackward && string[backwardCursor]) {
+			out = string[backwardCursor] + out
+			backwardCursor--
+		} else {
+			breakBackward = true
+		}
+		if (wordBoundaryCharacters) {
+			if (wordBoundaryCharacters.has(string[forwardCursor]) && out.length > (size - LOOK_AROUND)) breakForward = true
+			if (wordBoundaryCharacters.has(string[backwardCursor]) && out.length > (size - LOOK_AROUND)) breakBackward = true
+		}
+		if (breakForward && breakBackward) break
+	}
+
+	let before = backwardCursor + 1
+	let after = string.length - forwardCursor
+
+	if (wordBoundaryCharacters) {
+		let beforeIsAllWordBoundaries = true
+		for (let i = backwardCursor; i >= 0; i--) {
+			if (!wordBoundaryCharacters.has(string[i])) {
+				beforeIsAllWordBoundaries = false
+				break
+			}
+		}
+		if (beforeIsAllWordBoundaries) before = 0
+
+		let afterIsAllWordBoundaries = true
+		for (let i = string.length - 1; i >= forwardCursor; i--) {
+			if (!wordBoundaryCharacters.has(string[i])) {
+				afterIsAllWordBoundaries = false
+				break
+			}
+		}
+		if (afterIsAllWordBoundaries) after = 0
+	}
+
+	return {
+		string: out,
+		before,
+		after,
+	}
+}
+
+const naiveSnip = (string, snippetLength, queryString, wordBoundaryCharacters, fuzzy) => {
+	// If no query string is given, we can just snip the very start of the text.
+	if (!queryString) return approximateTextExtraction(string, 0, snippetLength, wordBoundaryCharacters)
+
+	// If a blind lookup finds it, that's the cheapest way, and we'll just
+	// grab the very first result.
+	const stringLower = string.toLowerCase()
+	const queryStringLower = queryString.toLowerCase()
+	let cursor = stringLower.split(queryStringLower)
+	if (cursor.length > 1) cursor = cursor[0].length
+	if (cursor >= 0) return approximateTextExtraction(string, cursor + Math.round(queryString.length / 2), snippetLength, wordBoundaryCharacters)
+
+	// If that doesn't find it, we are dealing with a query that
+	// maybe has spaces or is fuzzy or anything else, so we're going
+	// to try throwing it at MiniSearch in chunks.
+	const paragraphs = string.split('\n')
+	const options = fuzzy >= 0
+		? { fuzzy }
+		: {}
+	const miniSearch = new MiniSearch({ fields: [ 'p' ], ...options })
+	miniSearch.addAll(paragraphs.map((p, id) => ({ p, id })))
+	const match = miniSearch.search(queryString, options)?.[0]
+	if (match) {
+		let start = 0
+		let index = 0
+		for (const p of paragraphs) {
+			if (index === match.id) break
+			index++
+			start += (p.length + 1) // the +1 is for the `/n` split
+		}
+		// At this point we'll try again to find the first query
+		// word in the best-matching, but using the indexed term
+		// in case fuzzing causes a mismatch.
+		const firstQueryWordLower = match.terms[0]
+		const matchingParagraph = paragraphs[match.id]
+		cursor = matchingParagraph.toLowerCase().split(firstQueryWordLower)
+		if (cursor.length > 1) cursor = cursor[0].length
+		const out = approximateTextExtraction(matchingParagraph, cursor + Math.round(firstQueryWordLower.length / 2), snippetLength, wordBoundaryCharacters)
+		out.start = start + out.start
+		out.size = string.length
+		return out
+	}
+
+	// We couldn't find the query string. This is very peculiar, and I don't
+	// think it should happen, but as an emergency fallback we'll return the
+	// first text snippet.
+	return approximateTextExtraction(string, 0, snippetLength, wordBoundaryCharacters)
+}
+
+export const snipContent = ({ q, snippet: propertiesToSnip, fuzzy, wordBoundaryCharacters }, searchResult) => {
+	if (propertiesToSnip)
+		for (const key in propertiesToSnip) {
+			if (key === '_chunks.content') {
+				for (const chunk of searchResult._chunks) {
+					const { string, before, after } = naiveSnip(chunk.content, propertiesToSnip[key], q, wordBoundaryCharacters, fuzzy)
+					chunk.content = string
+					if (string) chunk.snippet = { content: { before, after } }
+				}
+			} else if (typeof searchResult[key] === 'string') {
+				const { string, before, after } = naiveSnip(searchResult[key], propertiesToSnip[key], q, wordBoundaryCharacters, fuzzy)
+				searchResult[key] = string
+				if (string) {
+					searchResult._snippet = searchResult._snippet || {}
+					searchResult._snippet[key] = { before, after }
+				}
+			}
+		}
+	delete searchResult.terms
+	delete searchResult.match
+	return searchResult
+}

--- a/test/feature/huge-text-search/basic.test.js
+++ b/test/feature/huge-text-search/basic.test.js
@@ -13,10 +13,18 @@ export default ({ assert, hunch, index }) => [
 					{
 						_id: 'romans/chapter-6.md',
 						_score: 6.103,
-						_chunks: [ { name: 'markdown', content: 'u should obey it in its lusts.  Also, do not present your members to sin as instruments of unrighteo' } ],
+						_chunks: [
+							{
+								name: 'markdown',
+								content: 'u should obey it in its lusts.  Also, do not present your members to sin as instruments of unrighteo',
+								snippet: {
+									content: { start: 1264, size: 2644 },
+								},
+							},
+						],
 					},
 				],
-				page: { offset: 0, size: 1, pages: 69, items: 69 },
+				page: { offset: 0, size: 1, pages: 69, items: 2 },
 			},
 			'make sure basic text lookup works',
 		)
@@ -38,7 +46,15 @@ export default ({ assert, hunch, index }) => [
 					{
 						_id: 'romans/chapter-6.md',
 						_score: 98.146,
-						_chunks: [ { name: 'markdown', content: 'hould obey it in its lusts.  Also, do not present your members to sin as instruments of unrighteousn' } ],
+						_chunks: [
+							{
+								name: 'markdown',
+								content: 'hould obey it in its lusts.  Also, do not present your members to sin as instruments of unrighteousn',
+								snippet: {
+									content: { start: 1267, size: 2644 },
+								},
+							},
+						],
 					},
 				],
 				page: { offset: 0, size: 1, pages: 775, items: 775 },

--- a/test/feature/huge-text-search/basic.test.js
+++ b/test/feature/huge-text-search/basic.test.js
@@ -16,15 +16,15 @@ export default ({ assert, hunch, index }) => [
 						_chunks: [
 							{
 								name: 'markdown',
-								content: 'u should obey it in its lusts.  Also, do not present your members to sin as instruments of unrighteo',
+								content: 'you should obey it in its lusts.  Also, do not present your members to sin as instruments of unrighteou',
 								snippet: {
-									content: { start: 1264, size: 2644 },
+									content: { before: 1162, after: 1379 },
 								},
 							},
 						],
 					},
 				],
-				page: { offset: 0, size: 1, pages: 69, items: 2 },
+				page: { offset: 0, size: 1, pages: 69, items: 69 },
 			},
 			'make sure basic text lookup works',
 		)
@@ -49,9 +49,9 @@ export default ({ assert, hunch, index }) => [
 						_chunks: [
 							{
 								name: 'markdown',
-								content: 'hould obey it in its lusts.  Also, do not present your members to sin as instruments of unrighteousn',
+								content: 'should obey it in its lusts.  Also, do not present your members to sin as instruments of unrighteousnes',
 								snippet: {
-									content: { start: 1267, size: 2644 },
+									content: { before: 1166, after: 1375 },
 								},
 							},
 						],

--- a/test/feature/snippet/basic.test.js
+++ b/test/feature/snippet/basic.test.js
@@ -9,14 +9,79 @@ export default ({ assert, hunch, index }) => [
 				items: [
 					{
 						_id: 'file1.md',
-						_score: 5.752,
+						_score: 13.005,
 						title: 'Ecclesiastes',
-						_chunks: [ { name: 'markdown', content: '\nThat which is crooked can’t b' } ],
+						_chunks: [
+							{
+								name: 'markdown',
+								content: 'wind.\nThat which is crooked can’t',
+								snippet: {
+									content: { before: 1499, after: 4780 },
+								},
+							},
+						],
 					},
 				],
 				page: { offset: 0, size: 15, pages: 1, items: 1 },
 			},
 			'setting a snippet size to limit returned data',
+		)
+	},
+	() => {
+		assert.equal(
+			hunch({ index })({
+				q: 'strikingly',
+				snippet: { '_chunks.content': 10 },
+			}).items[0]._chunks[0],
+			{
+				name: 'markdown',
+				content: 'strikingly',
+				snippet: {
+					content: {
+						before: '\nzebra now read a '.length, // 17
+						after: ' different word\n'.length, // 16
+					},
+				},
+			},
+			'before with word boundary characters',
+		)
+	},
+	() => {
+		assert.equal(
+			hunch({ index })({
+				q: 'read',
+				snippet: { '_chunks.content': 4 },
+			}).items[0]._chunks[0],
+			{
+				name: 'markdown',
+				content: 'read',
+				snippet: {
+					content: {
+						before: '\nzebra now '.length, // 14
+						after: ' a strikingly different word\n'.length, // 18
+					},
+				},
+			},
+			'setting a snippet size in the middle',
+		)
+	},
+	() => {
+		assert.equal(
+			hunch({ index })({
+				q: 'zebra',
+				snippet: { '_chunks.content': 5 },
+			}).items[0]._chunks[0],
+			{
+				name: 'markdown',
+				content: 'zebra',
+				snippet: {
+					content: {
+						before: 0,
+						after: ' now read a strikingly different word\n'.length, // 38
+					},
+				},
+			},
+			'setting a snippet size at the start',
 		)
 	},
 	() => {
@@ -29,14 +94,19 @@ export default ({ assert, hunch, index }) => [
 				items: [
 					{
 						_id: 'file1.md',
-						_score: 5.752,
+						_score: 13.005,
 						title: 'Ecclesiastes',
-						_chunks: [ { name: 'markdown', content: '' } ],
+						_chunks: [
+							{
+								name: 'markdown',
+								content: '',
+							},
+						],
 					},
 				],
 				page: { offset: 0, size: 15, pages: 1, items: 1 },
 			},
-			'if snippet size is zero the chunk returns but content is empty string',
+			'if snippet size is zero the chunk returns but content is empty string and snip not set',
 		)
 	},
 	() => {
@@ -45,7 +115,7 @@ export default ({ assert, hunch, index }) => [
 				q: 'heart',
 				snippet: { '_chunks.content': 15 },
 			}).items[0]._chunks[0].content,
-			' my heart to see',
+			'ed my heart to see',
 			'it has 13 results in the document but finds the "best" match in the document',
 		)
 	},
@@ -55,7 +125,7 @@ export default ({ assert, hunch, index }) => [
 				q: 'obtained',
 				snippet: { '_chunks.content': 15 },
 			}).items[0]._chunks[0].content,
-			've obtained for ',
+			'have obtained for',
 			'it only has 1 result in the document',
 		)
 	},
@@ -65,7 +135,7 @@ export default ({ assert, hunch, index }) => [
 				q: 'test with',
 				snippet: { '_chunks.content': 25 },
 			}).items[0]._chunks[0].content,
-			'w, I will test you with mi',
+			'now, I will test you with mi',
 			'a split word does a search',
 		)
 	},
@@ -83,8 +153,17 @@ export default ({ assert, hunch, index }) => [
 				q: 'flush',
 				snippet: { '_chunks.content': 30 },
 				fuzzy: 0.2,
-			}).items[0]._chunks[0].content,
-			'o cheer my flesh with wine, my',
+			}).items[0]._chunks[0],
+			{
+				name: 'markdown',
+				content: 'to cheer my flesh with wine, my',
+				snippet: {
+					content: {
+						before: 27,
+						after: 181,
+					},
+				},
+			},
 			'but with fuzziness it is found',
 		)
 	},

--- a/test/feature/snippet/content-basic/file2.md
+++ b/test/feature/snippet/content-basic/file2.md
@@ -1,0 +1,5 @@
+---
+title: file2
+---
+
+zebra now read a strikingly different word

--- a/test/snip-content.test.js
+++ b/test/snip-content.test.js
@@ -1,0 +1,201 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+
+import { snipContent } from '../src/utils/snip-content.js'
+
+test('snip content', () => {
+	assert.equal(
+		snipContent(
+			{
+				q: 'middle',
+				snippet: {
+					foo: 'middle'.length,
+				},
+			},
+			{
+				foo: 'dawn middle foot',
+			}),
+		{
+			foo: 'middle',
+			_snippet: {
+				foo: {
+					before: 'dawn '.length,
+					after: ' foot'.length,
+				},
+			},
+		},
+		'middle out',
+	)
+	assert.equal(
+		snipContent(
+			{
+				q: 'dawn',
+				snippet: {
+					foo: 'dawn'.length,
+				},
+			},
+			{
+				foo: 'dawn middle foot',
+			}),
+		{
+			foo: 'dawn',
+			_snippet: {
+				foo: {
+					before: 0,
+					after: ' middle foot'.length,
+				},
+			},
+		},
+		'start of string',
+	)
+	assert.equal(
+		snipContent(
+			{
+				q: 'foot',
+				snippet: {
+					foo: 'foot'.length,
+				},
+			},
+			{
+				foo: 'dawn middle foot',
+			}),
+		{
+			foo: 'foot',
+			_snippet: {
+				foo: {
+					before: 'dawn middle '.length,
+					after: 0,
+				},
+			},
+		},
+		'start of string',
+	)
+	assert.equal(
+		snipContent(
+			{
+				q: 'middle',
+				snippet: {
+					foo: 'middle'.length + 1,
+				},
+			},
+			{
+				foo: 'dawn middle foot',
+			}),
+		{
+			foo: 'middle',
+			_snippet: {
+				foo: {
+					before: 'dawn '.length,
+					after: ' foot'.length,
+				},
+			},
+		},
+		'middle out with the snippet over size',
+	)
+	assert.equal(
+		snipContent(
+			{
+				q: 'dawn',
+				snippet: {
+					foo: 'dawn'.length + 1,
+				},
+			},
+			{
+				foo: 'dawn middle foot',
+			}),
+		{
+			foo: 'dawn',
+			_snippet: {
+				foo: {
+					before: 0,
+					after: ' middle foot'.length,
+				},
+			},
+		},
+		'start with the snippet over size',
+	)
+	assert.equal(
+		snipContent(
+			{
+				q: 'foot',
+				snippet: {
+					foo: 'foot'.length + 1,
+				},
+			},
+			{
+				foo: 'dawn middle foot',
+			}),
+		{
+			foo: 'foot',
+			_snippet: {
+				foo: {
+					before: 'dawn middle '.length,
+					after: 0,
+				},
+			},
+		},
+		'end with the snippet over size',
+	)
+	assert.equal(
+		snipContent(
+			{
+				q: 'fizz',
+				snippet: {
+					foo: 6,
+				},
+			},
+			{
+				foo: '  fizz bar buzz  ',
+			}),
+		{
+			foo: 'fizz',
+			_snippet: {
+				foo: {
+					before: 0,
+					after: ' bar buzz  '.length,
+				},
+			},
+		},
+		'word boundaries at beginning are not counted',
+	)
+	assert.equal(
+		snipContent(
+			{
+				q: 'buzz',
+				snippet: {
+					foo: 6,
+				},
+			},
+			{
+				foo: '  fizz bar buzz  ',
+			}),
+		{
+			foo: 'buzz',
+			_snippet: {
+				foo: {
+					before: '  fizz bar '.length,
+					after: 0,
+				},
+			},
+		},
+		'word boundaries at end are not counted',
+	)
+	assert.equal(
+		snipContent(
+			{
+				q: 'bar',
+				snippet: {
+					foo: 0,
+				},
+			},
+			{
+				foo: 'fizz bar buzz',
+			}),
+		{
+			foo: '',
+		},
+		'when snippet size is 0 no chars are returned and _snippet is not set',
+	)
+})
+
+test.run()


### PR DESCRIPTION
Snippets are now slightly context aware and let you know if there are words before or after the result string.

Previously a snippet might have returned `izz buzz` but now will look around and attempt to complete the word, so you're more likely to end up with `fizz buzz`.

You'll also get a handy map, in `_snippet` at the root or `snippet` in each chunk, where the key is the snipped keypath and the value is a map:

```ts
{
  before: undefined | number;
  after: undefined | number;
}
```

The numbers are approximately how many characters left before or after the search result snip. For example, if your text looks like `\nfizz buzz\n` and the search result snips to just `fizz`, the before will be `undefined` or `0`, meaning there are no "word" characters before it.

It's maybe not as intuitive as I'd like, but basically you can key off the `before`/`after` values to determine whether to show ellipses, aka `fizz...` versus `...fizz...` versus just `fizz`.