### PR TITLE
Feature: add files to saveSite

### DIFF
--- a/.changeset/ninety-trainers-jam.md
+++ b/.changeset/ninety-trainers-jam.md
@@ -1,0 +1,5 @@
+---
+"hunch": minor
+---
+
+Add "files" to the API of "saveSite".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hunch",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hunch",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "hunch": "bin.js"

--- a/src/generate.js
+++ b/src/generate.js
@@ -65,7 +65,7 @@ export const generate = async options => {
 	console.log(`Parsed ${files.length} content files.`)
 
 	const site = mergeMetadata && mergeMetadata({ files })
-	if (saveSite) await saveSite({ site })
+	if (saveSite) await saveSite({ site, files })
 	const prepared = prepareFilesData && await prepareFilesData({ files, site })
 
 	console.log(`Processing ${files.length} files.`)

--- a/test/feature/huge-text-search/basic.test.js
+++ b/test/feature/huge-text-search/basic.test.js
@@ -61,6 +61,6 @@ export default ({ assert, hunch, index }) => [
 			},
 			'looking for long phrases',
 		)
-		assert.ok(duration < 1000, `approximate hard limit on time (duration=${duration})`)
+		assert.ok(duration < 2000, `approximate hard limit on time (duration=${duration})`)
 	},
 ]


### PR DESCRIPTION
Still lacking proper documentation, but the `saveSite` function previously had `{ site }` only, but now has `{ site, files }` for when you need to do a different merging for a file.