### PR TITLE
Fix: allow facets and fields to be empty in query

### DIFF
--- a/.changeset/thin-olives-own.md
+++ b/.changeset/thin-olives-own.md
@@ -1,0 +1,5 @@
+---
+"hunch": patch
+---
+
+Including fields and facets is now allowed to be empty.

--- a/src/to-query.js
+++ b/src/to-query.js
@@ -22,9 +22,12 @@ export const toQuery = query => {
 	if (query.pageOffset !== undefined) out['page[offset]'] = query.pageOffset.toString()
 	if (query.prefix) out.prefix = 'true'
 	if (query.suggest) out.suggest = 'true'
-	if (query.fields?.length) out.fields = query.fields.join(',')
-	if (query.includeFields?.length) out['include[fields]'] = query.includeFields.join(',')
-	if (query.includeFacets?.length) out['include[facets]'] = query.includeFacets.join(',')
+	if (query.fields) out.fields = query.fields.join(',')
+
+	// If the `include*` properties are arrays *at all* they should be
+	// respected. If they are empty arrays it means to exclude those.
+	if (Array.isArray(query.includeFields)) out['include[fields]'] = query.includeFields.join(',')
+	if (Array.isArray(query.includeFacets)) out['include[facets]'] = query.includeFacets.join(',')
 	if (query.includeMatches) out['include[matches]'] = ''
 
 	if (Array.isArray(query.sort) && query.sort.length)

--- a/test/to-query.test.js
+++ b/test/to-query.test.js
@@ -152,9 +152,19 @@ test('specific query parameter scenarios', () => {
 			{ 'include[fields]': 'foo,bar' },
 		],
 		[
+			'include fields is empty',
+			{ includeFields: [] },
+			{ 'include[fields]': '' },
+		],
+		[
 			'include facets',
 			{ includeFacets: [ 'foo', 'bar' ] },
 			{ 'include[facets]': 'foo,bar' },
+		],
+		[
+			'include facets is empty',
+			{ includeFacets: [] },
+			{ 'include[facets]': '' },
 		],
 	]
 	for (const [ label, query, expected ] of testEveryProperty)


### PR DESCRIPTION
This closes #57 as a bug.