### PR TITLE
feature: skip indexing, access record

### DIFF
--- a/.changeset/two-dodos-argue.md
+++ b/.changeset/two-dodos-argue.md
@@ -1,0 +1,5 @@
+---
+"hunch": minor
+---
+
+Add ability to skip index creation, and pass finalized record as `record` to `saveFile`.


### PR DESCRIPTION
## Skip Indexing

As part of ongoing client-based research into using alternate search algorithms, you can set `output` to `false` to explicitly skip the indexing portion of HunchJS. This allows for use of HunchJS to filter and normalize content, so you don't need to rewrite that functionality.

This isn't meant to be a widely used configuration option, so it will be left undocumented as it's a bit out of scope for normal use.

## Access `record`

In the `saveFile` function you can now access the output of `finalizeRecord` as the `record` property.