### PR TITLE
feature: better logging on metadata normalization errors

### DIFF
--- a/.changeset/young-shoes-jam.md
+++ b/.changeset/young-shoes-jam.md
@@ -1,0 +1,5 @@
+---
+"hunch": minor
+---
+
+Failure in metadata normalization will log with filename.


### PR DESCRIPTION
Previously, if your metadata normalization function threw an error, you wouldn't see the filename or problematic metadata.

After this change, you will! 🎉 